### PR TITLE
Fixed acces control

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -21,5 +21,4 @@ security:
         - { path: ^/login$, role: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: ^/register, role: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: ^/resetting, role: IS_AUTHENTICATED_ANONYMOUSLY }
-        - { path: ^/manager/*, role: IS_AUTHENTICATED_FULLY }
         - { path: ^/admin/*, role: ROLE_ADMIN }

--- a/src/AppBundle/Controller/DefaultController.php
+++ b/src/AppBundle/Controller/DefaultController.php
@@ -8,6 +8,7 @@ use AppBundle\Entity\Log;
 use AppBundle\Form\FolderType;
 use AppBundle\Form\ItemType;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 
 use Symfony\Component\HttpFoundation\Request;
@@ -16,6 +17,9 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Validator\Constraints\DateTime;
 
+/**
+ * @Security("is_granted('IS_AUTHENTICATED_FULLY')")
+ */
 class DefaultController extends Controller
 {
     public function redirectAction(Request $request)

--- a/src/AppBundle/Controller/FolderController.php
+++ b/src/AppBundle/Controller/FolderController.php
@@ -36,7 +36,7 @@ class FolderController extends Controller
 
     /**
      * This lists all main Folders which are hidden. Sorting by name.
-     * @Route("/hidden_list", name ="hiddenFolders")
+     * @Route("/manager/hidden_list", name ="hiddenFolders")
      * @Template
      */
     public function hiddenFolderListAction()

--- a/src/AppBundle/Controller/FolderController.php
+++ b/src/AppBundle/Controller/FolderController.php
@@ -8,12 +8,16 @@ use AppBundle\Form\FolderType;
 use AppBundle\Form\ItemType;
 use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
+/**
+ * @Security("is_granted('IS_AUTHENTICATED_FULLY')")
+ */
 class FolderController extends Controller
 {
     /**

--- a/src/AppBundle/Controller/ItemController.php
+++ b/src/AppBundle/Controller/ItemController.php
@@ -9,12 +9,16 @@ use AppBundle\Form\FolderType;
 use AppBundle\Form\ItemType;
 use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
+/**
+ * @Security("is_granted('IS_AUTHENTICATED_FULLY')")
+ */
 class ItemController extends Controller
 {
     /**

--- a/tests/AppBundle/Controller/FolderControllerTest.php
+++ b/tests/AppBundle/Controller/FolderControllerTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\AppBundle\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class FolderControllerTest extends WebTestCase
+{
+    /**
+     * @dataProvider protectedUrlProvider
+     */
+    public function testPagesAreProperlyProtected($url)
+    {
+        $client = $client = self::createClient();
+
+        $client->request('GET', $url);
+
+        $this->assertSame($client->getResponse()->getStatusCode(), 302);
+        $this->assertSame($client->getResponse()->headers->get('Location'), 'http://localhost/login');
+    }
+
+    public function protectedUrlProvider()
+    {
+        return [
+            ['/en/manager'],
+            ['/en/manager/hidden_list'],
+            ['/en/manager/create_folder'],
+            ['/en/manager/edit_folder/123'],
+            ['/en/manager/createFolder/123'],
+            ['/en/manager/123/delete/xyz'],
+        ];
+    }
+
+}

--- a/tests/AppBundle/Controller/ItemControllerTest.php
+++ b/tests/AppBundle/Controller/ItemControllerTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\AppBundle\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class ItemControllerTest extends WebTestCase
+{
+    /**
+     * @dataProvider protectedUrlProvider
+     */
+    public function testPagesAreProperlyProtected($url)
+    {
+        $client = $client = self::createClient();
+
+        $client->request('GET', $url);
+
+        $this->assertSame($client->getResponse()->getStatusCode(), 302);
+        $this->assertSame($client->getResponse()->headers->get('Location'), 'http://localhost/login');
+    }
+
+    public function protectedUrlProvider()
+    {
+        return [
+            ['/en/manager/123'],
+            ['/en/manager/item/log/123'],
+            ['/en/manager/create/123'],
+            ['/en/manager/123/edit/456'],
+            ['/en/manager/123/delete/456/xyz'],
+        ];
+    }
+
+}


### PR DESCRIPTION
Previously, all URLs below "/xx/manager" were accessible, because the pattern in security.yml only matched "/manager" without a language prefix.

An alternative fix would be to replace the line
`- { path: ^/manager/*, role: IS_AUTHENTICATED_FULLY }`
with something like
`- { path: ^/../manager/*, role: IS_AUTHENTICATED_FULLY }`

But using the "@Security" annotation is easier to read.

Also, /hidden_list was not protected at all, so I also moved it below "/manager".
I also added tests to ensure the URLs are all protected.